### PR TITLE
Add `public` directory to avoid build error

### DIFF
--- a/.github/workflows/prerelease-build.yml
+++ b/.github/workflows/prerelease-build.yml
@@ -123,10 +123,6 @@ jobs:
         continue-on-error: true
         run: mkdir dist
 
-      - name: Create 'public' directory
-        continue-on-error: true
-        run: mkdir public
-
       - name: Build the app
         run: |
           cargo tauri build

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,3 +1,0 @@
-*
-
-!.gitignore

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,18 +43,18 @@ sqlx = { version = "0.7.3", features = ["sqlite", "runtime-tokio"] }
 sublime_fuzzy = "0.7.0"
 tauri = { version = "1.5.4", features = [
     "api-all",
-    "icon-png",
-    "icon-ico",
-    "config-toml",
-    "config-json5",
-    "windows7-compat",
-    "fs-extract-api",
-    "process-relaunch-dangerous-allow-symlink-macos",
-    "process-command-api",
     "clipboard",
+    "config-json5",
+    "config-toml",
+    "fs-extract-api",
     "global-shortcut",
-    "system-tray",
+    "icon-ico",
+    "icon-png",
     "notification",
+    "process-command-api",
+    "process-relaunch-dangerous-allow-symlink-macos",
+    "system-tray",
+    "windows7-compat",
 ] }
 
 [features]


### PR DESCRIPTION
When building (or running in development mode) the app, without `public` directory under root path, an error will occur:

``` log
2024-01-12T16:19:50.561736Z ERROR  error
error from HTML pipeline

Caused by:
    0: error from asset pipeline
    1: error taking canonical path of directory "\\\\?\\E:\\PublicRepo\\CopyClip\\public"     
    2: The system cannot find the file specified. (os error 2)
```

After this pr, the issue can be resolved:

``` log
2024-01-12T16:32:47.351923Z  INFO copying directory path="\\\\?\\E:\\PublicRepo\\CopyClip\\public"
```

---

I think this is probably caused by `trunk`:

https://github.com/Alex222222222222/CopyClip/blob/d88ad40777fb1c7c8ee68e3c398aa7bf72c81a9a/index.html#L8

I tried to remove it. After some crude testing, the app seems still work well.

Probably this is a better approach.