### PR TITLE
Add ability to clear clip history

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -13,6 +13,8 @@ preferences:
   language: Sprache
   search_clip_per_batch: Such Clips pro Batch
   enable_auto_delete_duplications: Duplikate automatisch löschen
+  clear_history_button: Verlauf löschen
+  clear_history_confirm_button: Zum Bestätigen erneut klicken
 
 head_bar:
   preferences: Einstellungen
@@ -62,5 +64,7 @@ tray_menu:
   preferences: Einstellungen
   search: Suche
   quit: Beenden
+  clear_history: Verlauf löschen
+  clear_history_confirm: Dadurch werden alle Clips im Verlauf dauerhaft gelöscht, außer angehefteten Clips. Fortfahren?
   total_clips: Gesamtanzahl der Clips
   current_page: Aktuelle Seite

--- a/locales/en-GB.yml
+++ b/locales/en-GB.yml
@@ -13,6 +13,8 @@ preferences:
   language: Language
   search_clip_per_batch: Search Clips Per Batch
   enable_auto_delete_duplications: Enable Auto Delete Duplications
+  clear_history_button: Clear History
+  clear_history_confirm_button: Click again to confirm
 
 head_bar:
   preferences: Preferences
@@ -62,5 +64,7 @@ tray_menu:
   preferences: Preferences
   search: Search
   quit: Quit
+  clear_history: Clear History
+  clear_history_confirm: This will permanently delete all clips in your history, except pinned clips. Continue?
   total_clips: Total Clips
   current_page: Current Page

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -13,6 +13,8 @@ preferences:
   language: Language
   search_clip_per_batch: Search Clips Per Batch
   enable_auto_delete_duplications: Enable Auto Delete Duplications
+  clear_history_button: Clear History
+  clear_history_confirm_button: Click again to confirm
 
 head_bar:
   home: Home
@@ -62,5 +64,7 @@ tray_menu:
   preferences: Preferences
   search: Search
   quit: Quit
+  clear_history: Clear History
+  clear_history_confirm: This will permanently delete all clips in your history, except pinned clips. Continue?
   total_clips: Total Clips
   current_page: Current Page

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -9,6 +9,8 @@ preferences:
   language: 语言
   search_clip_per_batch: 每次搜索的数量
   enable_auto_delete_duplications: 自动删除重复记录
+  clear_history_button: 清空历史记录
+  clear_history_confirm_button: 再次点击以确认
 
 head_bar:
   home: 主页
@@ -58,5 +60,7 @@ tray_menu:
   preferences: 设置
   search: 搜索
   quit: 退出
+  clear_history: 清空历史记录
+  clear_history_confirm: 此操作将永久删除历史记录中的所有记录（置顶记录除外），是否继续？
   total_clips: 总历史记录
   current_page: 当前页

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,8 @@ tauri = { version = "1.7", features = [
 
     "system-tray",
     "windows7-compat",
+
+    "dialog-ask",
 ] }
 tauri-plugin-clipboard = "1.0"
 clip = { path = "../src-clip" }

--- a/src-tauri/src/clip/clip_data.rs
+++ b/src-tauri/src/clip/clip_data.rs
@@ -291,6 +291,29 @@ impl ClipState {
         Ok(())
     }
 
+    /// Delete all clips from the database and the cache, except pinned clips.
+    ///
+    /// Will trigger a tray update event.
+    pub async fn clear_clips(&mut self, app: &AppHandle) -> Result<(), Error> {
+        let db_connection = app.state::<DatabaseStateMutex>();
+        let db_connection = db_connection.database_connection.lock().await;
+        match db_connection.execute(
+            &format!(
+                "DELETE FROM clips WHERE id NOT IN (SELECT id FROM {})",
+                label_name_to_table_name("pinned")
+            ),
+            [],
+        ) {
+            Ok(_) => (),
+            Err(err) => return Err(Error::DatabaseWriteErr(err.to_string())),
+        };
+        drop(db_connection);
+
+        self.trigger_tray_update_event(app).await;
+
+        Ok(())
+    }
+
     /// Change the current page to the first page.
     ///
     /// Will try lock `clips`.

--- a/src-tauri/src/clip/mod.rs
+++ b/src-tauri/src/clip/mod.rs
@@ -106,6 +106,31 @@ pub async fn delete_clip_from_database(
     Ok(())
 }
 
+/// Delete all clips from the database, except pinned clips
+#[tauri::command]
+pub async fn clear_clip_history(
+    app: tauri::AppHandle,
+    clip_state: tauri::State<'_, ClipStateMutex>,
+    event_sender: tauri::State<'_, EventSender>,
+) -> Result<(), String> {
+    let mut clip_state_mutex = clip_state.clip_state.lock().await;
+    let res = clip_state_mutex.clear_clips(&app).await;
+    drop(clip_state_mutex);
+
+    if let Err(err) = res {
+        return Err(err.to_string());
+    }
+
+    event_sender.send(CopyClipEvent::RebuildTrayMenuEvent).await;
+    event_sender
+        .send(CopyClipEvent::SendNotificationEvent(
+            "Clip history cleared.".to_string(),
+        ))
+        .await;
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn change_favourite_clip(
     app: tauri::AppHandle,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,6 +118,7 @@ fn main() {
             clip::switch_pinned_status,
             clip::copy_clip_to_clipboard,
             clip::delete_clip_from_database,
+            clip::clear_clip_history,
             clip::change_favourite_clip,
             clip::search::search_clips,
             clip::search::get_max_id,

--- a/src-tauri/src/systray/mod.rs
+++ b/src-tauri/src/systray/mod.rs
@@ -63,6 +63,8 @@ pub fn create_tray_menu(
         t!("tray_menu.pause_monitoring")
     };
     let pause = CustomMenuItem::new("pause".to_string(), text);
+    let clear_history =
+        CustomMenuItem::new("clear_history".to_string(), t!("tray_menu.clear_history"));
 
     let quit = CustomMenuItem::new("quit".to_string(), t!("tray_menu.quit"));
     let mut tray_menu = SystemTrayMenu::new()
@@ -103,6 +105,7 @@ pub fn create_tray_menu(
         .add_item(preferences)
         .add_item(search)
         .add_item(pause)
+        .add_item(clear_history)
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(quit)
 }
@@ -134,12 +137,15 @@ pub fn create_tray_menu(
         t!("tray_menu.pause_monitoring")
     };
     let pause = CustomMenuItem::new("pause".to_string(), text);
+    let clear_history =
+        CustomMenuItem::new("clear_history".to_string(), t!("tray_menu.clear_history"));
 
     let quit = CustomMenuItem::new("quit".to_string(), t!("tray_menu.quit"));
     let mut tray_menu = SystemTrayMenu::new();
     tray_menu = tray_menu
         .add_item(quit)
         .add_native_item(SystemTrayMenuItem::Separator)
+        .add_item(clear_history)
         .add_item(pause)
         .add_item(search)
         .add_item(preferences)
@@ -318,6 +324,28 @@ pub async fn handle_menu_item_click(app: &AppHandle, id: String) {
                     }
                 });
             }
+        }
+        "clear_history" => {
+            debug!("Clear history clicked, asking for confirmation");
+            let app_handle = app.app_handle();
+            tauri::api::dialog::ask(
+                None::<&tauri::Window>,
+                t!("tray_menu.clear_history"),
+                t!("tray_menu.clear_history_confirm"),
+                move |confirmed| {
+                    if !confirmed {
+                        return;
+                    }
+                    tauri::async_runtime::spawn(async move {
+                        let clip_data = app_handle.state::<ClipStateMutex>();
+                        let mut clip_data = clip_data.clip_state.lock().await;
+                        let res = clip_data.clear_clips(&app_handle).await;
+                        if let Err(e) = res {
+                            warn!("Failed to clear history: {}", e);
+                        }
+                    });
+                },
+            );
         }
         "pause" => {
             debug!("Pause clicked, Toggling pause monitoring");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,9 @@
       },
       "notification": {
         "all": true
+      },
+      "dialog": {
+        "ask": true
       }
     },
     "bundle": {

--- a/src/components/preferences/clear_history_button.rs
+++ b/src/components/preferences/clear_history_button.rs
@@ -1,0 +1,49 @@
+/// the button used to clear the clip history, except pinned clips
+///
+/// Native `window.confirm` dialogs are not implemented by wry's WebKitGTK
+/// backend on Linux, so a native confirm would silently do nothing.
+/// Instead the button requires two clicks: the first arms it, the second
+/// (while armed) performs the deletion.
+use serde_wasm_bindgen::to_value;
+use wasm_bindgen_futures::spawn_local;
+use yew::{function_component, html, use_state, Callback, Html};
+
+use crate::invoke::invoke;
+
+#[function_component(ClearHistoryButton)]
+pub fn clear_history_button() -> Html {
+    let armed = use_state(|| false);
+
+    let clear_history_button_on_click = {
+        let armed = armed.clone();
+        Callback::from(move |_| {
+            if !*armed {
+                armed.set(true);
+                return;
+            }
+
+            armed.set(false);
+            spawn_local(async move {
+                let args = to_value(&()).unwrap();
+                invoke("clear_clip_history", args).await;
+            });
+        })
+    };
+
+    let label = if *armed {
+        t!("preferences.clear_history_confirm_button")
+    } else {
+        t!("preferences.clear_history_button")
+    };
+
+    html! (
+        <button
+            class="search-button bg-black my-2"
+            onclick={clear_history_button_on_click}
+        >
+            <span
+                class="dark:bg-white dark:text-black text-white"
+            > {label} </span>
+        </button>
+    )
+}

--- a/src/components/preferences/mod.rs
+++ b/src/components/preferences/mod.rs
@@ -1,3 +1,4 @@
+pub mod clear_history_button;
 pub mod clips_per_page_config;
 pub mod clips_search_per_batch;
 pub mod dark_mode_switch;

--- a/src/pages/preferences.rs
+++ b/src/pages/preferences.rs
@@ -3,7 +3,7 @@ use yew::{function_component, html, Html};
 use crate::components::{
     head_bar::HeadBar,
     preferences::{
-        clips_per_page_config::ClipsPerPageConfig,
+        clear_history_button::ClearHistoryButton, clips_per_page_config::ClipsPerPageConfig,
         clips_search_per_batch::SearchClipPerBatchConfig, dark_mode_switch::DarkModeSwitch,
         export_button::ExportButton, language_config::LanguagesConfig,
         log_level_filter_config::LogLevelFilterConfig, max_clip_len_config::MaxClipLenConfig,
@@ -29,6 +29,8 @@ pub fn preferences() -> Html {
                 <LanguagesConfig></LanguagesConfig>
                 <br />
                 <ExportButton></ExportButton>
+                <br />
+                <ClearHistoryButton></ClearHistoryButton>
             </div>
 
             <h2 class="text-center text-4xl m-0">{ t!("preferences.advanced_title") }</h2>


### PR DESCRIPTION
## Summary

Adds the ability to clear the clip history, available from two places:

- **Preferences page**: a new "Clear History" button. Since native `window.confirm` dialogs aren't implemented by wry's WebKitGTK backend on Linux, the button uses a two-click arm/confirm pattern instead (first click arms it, second click confirms and deletes).
- **Tray menu**: a new "Clear History" entry that shows a native OS confirmation dialog before deleting (via the `dialog-ask` allowlist/feature), since a context menu closes on every click and can't use the same two-click pattern.

In both cases, pinned clips are preserved; only non-pinned clips are deleted.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (root, `src-tauri`, `src-clip`, `tauri-plugin-logging`)
- [x] `cargo tauri build` (release build + bundling)
- [x] Manually verified in `cargo tauri dev`: Preferences button clears history after two clicks, pinned clips survive, tray menu entry shows a confirmation dialog and clears history on confirm
